### PR TITLE
Manifests: Use ZP remote for sdk-zephyr and nrfxlib

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -39,6 +39,8 @@ manifest:
       url-base: https://github.com/BabbleSim
     - name: bosch
       url-base: https://github.com/boschsensortec
+    - name: zonneplan
+      url-base: git@github.com:zonneplan
 
   # If not otherwise specified, the projects below should be obtained
   # from the ncs remote.
@@ -61,7 +63,8 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: sdk-zephyr
-      revision: 83980fe1679441be9b0e1db556a353f6118fe14f
+      revision: zp/v3.4.99-ncs1-branch
+      remote: zonneplan
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above
@@ -142,6 +145,7 @@ manifest:
       repo-path: sdk-nrfxlib
       path: nrfxlib
       revision: v2.5.1-rc1
+      remote: zonneplan
     - name: trusted-firmware-m
       repo-path: sdk-trusted-firmware-m
       path: modules/tee/tf-m/trusted-firmware-m


### PR DESCRIPTION
Use the Zonneplan forks for sdk-zephyr and nrfxlib.